### PR TITLE
Fixed: entitiesReducer logs error if initial state is empty and there are no custom reducers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,14 @@ const resolveAction = (reducers = {}, state, action) => {
         [curr]: noOpReducer,
       };
     }, {});
-  return combineReducers(Object.assign({}, baseReducers, reducers))(
-    state,
-    action
-  );
+  const mergedReducers = Object.assign({}, baseReducers, reducers);
+  if (Object.keys(mergedReducers).length) {
+    return combineReducers(Object.assign({}, baseReducers, reducers))(
+      state,
+      action
+    );
+  }
+  return state;
 };
 
 export default (

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -198,4 +198,15 @@ describe('entitiesReducer', () => {
     console.error = error;
     /* eslint-enable no-console */
   });
+  
+  it('should handle no custom reducers and empty initial state', () => {
+    /* eslint-disable no-console */
+    const error = console.error;
+    console.error = jest.fn();
+    const result = entitiesReducer({})({}, {});
+    expect(console.error).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+    console.error = error;
+    /* eslint-enable no-console */
+  });
 });


### PR DESCRIPTION
added test and was able to recreate the issue where error gets thrown if state is empty and there are no custom reducers.
Error: Store does not have a valid reducer. Make sure the argument passed to combineReducers is an object whose values are reducers.

fixed by only calling combine reducers if there is anything to reduce:
https://github.com/reactjs/redux/issues/968
